### PR TITLE
feat(logging): add TRIM_LOG_SPACES + sed log filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The following options can be configured:
 | `Persistent Authentication` | Enables caching of authentication tokens. This prevents the need to re-authenticate via the web browser on every server restart. | `ENABLED` |
 | `Memory overhead` | The amount of RAM (in MB) kept aside for the system so the server doesn’t use everything. Java will get the rest. | `0` |
 | `Logger Level` | Sets the logging level for specific components. Use a comma-separated list in the format LoggerName:LEVEL (for example, com.example:INFO) to control how much detail is logged. | `empty` |
+| `Trim Log Padding` | Collapses excessive spacing in log lines (for example between the level and component tag) to improve console readability. | `false` |
 | `Source Query Support` | Automatically installs the Hytale Source Query plugin, allowing external services to query server status. | `false` |
 | `Validate Assets` | Causes the server to exit with an error code if assets are invalid. Leave empty to skip validation. | `false` |
 | `Validate prefabs` | Forces the server to stop and exit with an error if any specified prefab types are invalid. Provide a comma-separated list of prefab categories (e.g. PHYSICS,BLOCKS,BLOCK_STATES,ENTITIES,BLOCK_FILLER) to check. Leave empty to skip validation. | `0` |

--- a/egg-hytale.pelican.json
+++ b/egg-hytale.pelican.json
@@ -256,6 +256,18 @@
             "sort": 18
         },
         {
+            "name": "Trim Log Padding",
+            "description": "Collapses excessive spacing in log lines (for example between the level and component tag) to improve console readability.",
+            "env_variable": "TRIM_LOG_SPACES",
+            "default_value": "0",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "boolean"
+            ],
+            "sort": 19
+        },
+        {
             "name": "Maximum Backups",
             "description": "The maximum number of backups to keep. When this limit is reached, the oldest backups will be deleted automatically.",
             "env_variable": "MAXIMUM_BACKUPS",

--- a/egg-hytale.pterodactyl.json
+++ b/egg-hytale.pterodactyl.json
@@ -211,6 +211,16 @@
             "field_type": "text"
         },
         {
+            "name": "Trim Log Padding",
+            "description": "Collapses excessive spacing in log lines (for example between the level and component tag) to improve console readability.",
+            "env_variable": "TRIM_LOG_SPACES",
+            "default_value": "0",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean",
+            "field_type": "text"
+        },
+        {
             "name": "Require Valid World Generation",
             "description": "Causes the server to exit with an error code if world gen is invalid.",
             "env_variable": "VALIDATE_WORLD_GENERATION",

--- a/start.sh
+++ b/start.sh
@@ -104,4 +104,15 @@ JAVA_CMD="${JAVA_CMD} --bind 0.0.0.0:${SERVER_PORT}"
 
 # Execute the command
 #echo "$JAVA_CMD"
-eval $JAVA_CMD
+if [ "${TRIM_LOG_SPACES}" = "1" ]; then
+    set -o pipefail
+    # Reduce excessive padding before component tags like [NPC] without changing the message body.
+    eval "$JAVA_CMD" 2>&1 | sed -u -E \
+        -e 's/\] {2,}\[/] [/' \
+        -e 's/^(\[[0-9]{4}\/[0-9]{2}\/[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}) {2,}/\1 /'
+    EXIT_CODE=${PIPESTATUS[0]}
+    set +o pipefail
+    exit $EXIT_CODE
+else
+    eval $JAVA_CMD
+fi


### PR DESCRIPTION
Add TRIM_LOG_SPACES option to reduce excessive whitespace in startup logs. 
Update start.sh to filter logs via sed.